### PR TITLE
wip self signed CA

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config">
         <service
             android:name=".printservice.CupsService"
             android:exported="true"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
I submitted PR since I didn't know how to contact you. I have an idea for two improvements:
1. If you put printer address https://myprinter.domain.com/printers/p it change to  https://myprinter.domain.com:631/printers/p. It is done silently so it is hard to work out why things does not work. imho it would be better to use default ports if someone puts http:// or https://
2. In android it is possible to add self signed CA. It would be nice if app trust this kind of certs instead of waiting for confirmation.